### PR TITLE
ログイン機能追加（メールアドレスのみ）

### DIFF
--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -90,6 +90,7 @@
     &__login-no-account {
       padding: 40px 64px;
       text-align: center;
+      border-bottom: 1px solid #eee;
       p {
         font-size: 14px;
       }
@@ -104,18 +105,17 @@
     }
     &__login-form-inner {
       padding: 32px 64px;
-      border-top: 1px solid #eee;
       &:first-child {
         padding: 24px 64px 32px;
         border: 0;
       }
     }
     &__form-group {
-        margin: 24px 0 0;
-        &:first-child {
-          margin: 0;
-        }
+      margin: 24px 0 0;
+      &:first-child {
+        margin: 0;
       }
+    }
     &__input-default {
       height: 48px;
       width: 100%;

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,10 +1,12 @@
 .single-container
   = render partial: "shared/new-header"
   %main.single-main
+
     .login-panel
       .login-panel__login-no-account
         %p アカウントをお持ちでない方はこちら
-        %a{href: "https://www.mercari.com/jp/signup/"} 新規会員登録
+        = link_to "新規会員登録", signup_path
+
       .login-panel__login-form-inner
         %button#facebook-login.login-panel__btn-default.login-panel__btn-sns.login-panel__btn-sns__facebook
           %i.icon-facebook
@@ -12,15 +14,17 @@
         %button#google-login.login-panel__btn-default.login-panel__btn-sns.login-panel__btn-sns__google
           %i.icon-google-plus
           Googleでログイン
-      %form.login-panel__login-form{action: "https://www.mercari.com/jp/login/", method: "POST", novalidate: "novalidate"}
+
+      .login-panel__login-form
         .login-panel__login-form-inner
-          .login-panel__login-form-inner__form-group
-            %input.login-input-text.login-panel__input-default{name: "email", placeholder:  "メールアドレス", type: "email", value: ""}/
-          .login-panel__form-group
-            %input.login-input-text.login-panel__input-default{name: "password", placeholder:  "パスワード", type: "password"}/
-          .login-panel__form-group
-            .g-recaptcha.login-captcha{"data-sitekey": ""}
-          %button.login-submit.login-panel__btn-default.login-panel__btn-red{type: "submit"} ログイン
-          %input{name: "__csrf_value", type: "hidden", value: ""}/
-          %a{href: "https://www.mercari.com/jp/password/reset/start/"} パスワードをお忘れの方
+          = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+            .login-panel__form-group
+              = f.email_field :email, placeholder: "メールアドレス", autofocus: true, class: "login-input-text login-panel__input-default"
+            .login-panel__form-group
+              = f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "login-input-text login-panel__input-default"
+
+              / =recaptcha_tags site_key: 後で実装
+              = f.submit "ログイン", class: "login-submit login-panel__btn-default login-panel__btn-red"
+            = link_to "パスワードをお忘れの方",""
+
   = render partial: "shared/new-footer"

--- a/app/views/shared/_sidebar.html.haml
+++ b/app/views/shared/_sidebar.html.haml
@@ -94,6 +94,6 @@
           電話番号の確認
           %i.icon-arrow-right
       %li
-        = link_to "", class: "mypage-nav__list-item" do
+        = link_to logout_users_path, class: "mypage-nav__list-item" do
           ログアウト
           %i.icon-arrow-right

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -4,10 +4,9 @@
   %main.l-container.l-container__clearfix
     .mypage-content
       .mypage-content__chapter-container
-        %form.mypage-content__inner{action: "", method: "POST"}
+        .mypage-content__inner
           .mypage-content__single-content
-            %button.mypage-content__btn-default.mypage-content__single-content__btn-red{:type => "submit"} ログアウト
-            %input{:name => "__csrf_value", :type => "hidden", :value => ""}
+            =link_to "ログアウト", destroy_user_session_path, method: :delete, class: "mypage-content__btn-default mypage-content__single-content__btn-red"
     = render partial: "shared/sidebar"
   = render partial: "shared/footer"
   = render partial: "shared/sell_btn"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,7 +7,8 @@
         = link_to "" do
           %figure
             = image_tag "https://static-mercari-jp-imgtr2.akamaized.net/images/member_photo_noimage_thumb.png", size: "60x60"
-          %h2.bold テストユーザ
+          %h2.bold
+            = current_user.nickname
           .mypage-content__number
             %div
               評価


### PR DESCRIPTION
# What
- 取り急ぎメールアドレスによるログイン機能の追加
（メールアドレス新規登録のプルリクの際に漏れていたので）
- ログアウトの実装
- 余談：reCAPTCHA,Omniauthは別ブランチで実装済、
　ステップフォーム実装済み次第プルリクします。
　そのマージが済み次第、ログイン時のreCAPTCHAを実装します。

# Why
- 後の開発に差し障るため。
- サービスに必須の内容のため。


### ログイン動画
 https://gyazo.com/ae9589c8c94cb4430645aaa8159eb4fe

###  ログアウト動画
 https://gyazo.com/682d71f7cce5aaa0f660eee960964a2f